### PR TITLE
Added parse_dates['datetime'] for automated datetime parsing on CSV read

### DIFF
--- a/analyze-experiment.py
+++ b/analyze-experiment.py
@@ -24,7 +24,7 @@ print "Input file: " + inputFileName
 
 print "Read CSV file..."
 
-df = pd.read_csv(inputFileName, sep='|')
+df = pd.read_csv(inputFileName, parse_dates=['datetime'], sep='|')
 
 print "Done."
 


### PR DESCRIPTION
Timo requested a change for automagically parsing the datetime field. Here it is, done by passing the parse_dates=['datetime'] parameter to pd.read_csv.
